### PR TITLE
Refactor sandbox rendering for safer isolation

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -93,34 +93,17 @@ class TypechoCodeHighlight_Plugin implements Typecho_Plugin_Interface
         } else {
             $showln = false;
         }
+        $showLineNumber = json_encode($showln);
+        $styleName = htmlspecialchars($style, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+        $root = htmlspecialchars($rootDirname, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
         echo <<<HTML
-        <script type="text/javascript" src="{$rootDirname}/index.js"></script>
+        <script type="text/javascript" src="{$root}/index.js"></script>
         <script type="text/javascript">
-            const preList = document.getElementsByTagName('pre')
-            const codeList = []
-            for (let i = 0; i < preList.length; i++) {
-                const codepre = preList[i]
-                if (codepre.children[0].tagName === 'CODE') {
-                    const language = codepre.children[0].className.split(' ')[0].split('lang-')[1]
-                    const content = codepre.children[0].innerHTML
-
-                    codeList[i] = {
-                        originalElement: codepre,
-                        language,
-                        content,
-                    }
-                }
-            }
-            // 在上个for循环中直接操作节点会实时改变preList数组长度，并且使用反循环的话页面会从低到高渲染
-            Promise.all(codeList.map((item, index) => {
-                codeList[index].iframe = new IframeSandbox({
-                    showln: "{$showln}",
-                    cssName: "{$style}",
-                    content: item.content,
-                    language: item.language,
-                    originalElement: item.originalElement,
-                }, "{$rootDirname}")
-            }))
+            window.TypechoCodeHighlight.render({
+                rootDirname: "{$root}",
+                styleName: "{$styleName}",
+                showLineNumber: {$showLineNumber},
+            });
         </script>
         HTML;
     }

--- a/highlight/template.html
+++ b/highlight/template.html
@@ -4,7 +4,8 @@
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>TypechoCodeHighlight</title>
-		<link rel="stylesheet" type="text/css" href="./highlightjs-line.css" />
+                <link rel="stylesheet" type="text/css" href="./highlightjs-line.css" />
+                <link rel="stylesheet" type="text/css" id="theme-style" href="" />
 		<script src="./highlight.min.js"></script>
 		<script src="./highlightjs-line-numbers.min.js"></script>
 		<style>
@@ -91,8 +92,95 @@
 			<span class="title"></span>
 			<span class="copy">复制</span>
 		</div>
-		<pre>
+                <pre>
             <code></code>
         </pre>
-	</body>
+                <script>
+                        (function () {
+                                'use strict';
+
+                                var themeLink = document.getElementById('theme-style');
+                                var codeElement = document.querySelector('code');
+                                var titleElement = document.querySelector('.title');
+                                var copyElement = document.querySelector('.copy');
+                                var resizeObserver = null;
+
+                                function isValidStyleName(name) {
+                                        return typeof name === 'string' && /^[\w-]+$/.test(name);
+                                }
+
+                                function applyTheme(name) {
+                                        var styleName = isValidStyleName(name) ? name : 'atom-one-light';
+                                        themeLink.href = './styles/' + styleName + '.min.css';
+                                        var theme = styleName.indexOf('dark') !== -1 ? 'dark' : 'light';
+                                        document.documentElement.setAttribute('theme', theme);
+                                }
+
+                                function notifyResize() {
+                                        var height = document.body.scrollHeight;
+                                        parent.postMessage({
+                                                type: 'resize',
+                                                payload: { height: height },
+                                        }, '*');
+                                }
+
+                                function highlightCode(language, content, showLineNumber) {
+                                        codeElement.className = '';
+                                        if (language) {
+                                                codeElement.classList.add('language-' + language);
+                                        }
+                                        titleElement.textContent = language || 'code';
+                                        codeElement.textContent = content || '';
+                                        if (window.hljs && typeof window.hljs.highlightElement === 'function') {
+                                                window.hljs.highlightElement(codeElement);
+                                                if (showLineNumber && window.hljs.lineNumbersBlock) {
+                                                        window.hljs.lineNumbersBlock(codeElement);
+                                                }
+                                        }
+                                        requestAnimationFrame(notifyResize);
+                                }
+
+                                function handleCopy() {
+                                        var text = codeElement.textContent || '';
+                                        if (!navigator.clipboard || typeof navigator.clipboard.writeText !== 'function') {
+                                                console.warn('Clipboard API is not available in this environment.');
+                                                return;
+                                        }
+                                        navigator.clipboard.writeText(text).then(function () {
+                                                copyElement.textContent = '已复制';
+                                                copyElement.style.color = '#2080f0';
+                                                setTimeout(function () {
+                                                        copyElement.textContent = '复制';
+                                                        copyElement.style.color = '#666';
+                                                }, 1000);
+                                        }).catch(function (error) {
+                                                console.error('Failed to copy: ', error);
+                                        });
+                                }
+
+                                copyElement.addEventListener('click', handleCopy);
+
+                                if (typeof ResizeObserver === 'function') {
+                                        resizeObserver = new ResizeObserver(function () {
+                                                notifyResize();
+                                        });
+                                        resizeObserver.observe(document.body);
+                                } else {
+                                        window.addEventListener('load', notifyResize);
+                                }
+
+                                window.addEventListener('message', function (event) {
+                                        var data = event.data || {};
+                                        if (data.type !== 'render' || !data.payload) {
+                                                return;
+                                        }
+                                        var payload = data.payload;
+                                        applyTheme(payload.cssName);
+                                        highlightCode(payload.language, payload.content, payload.showLineNumber);
+                                });
+
+                                parent.postMessage({ type: 'ready' }, '*');
+                        })();
+                </script>
+        </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -1,96 +1,133 @@
-class IframeSandbox {
-	// 创建公有属性
-	iframe = null;
-	window = null;
+(function (global) {
+    'use strict';
 
-	showln = false;
-	cssName = "";
-	content = "";
-	language = "";
+    function detectLanguage(codeElement) {
+        if (!codeElement || !codeElement.className) {
+            return '';
+        }
+        var classes = codeElement.className.split(/\s+/);
+        for (var i = 0; i < classes.length; i += 1) {
+            var cls = classes[i];
+            if (!cls) {
+                continue;
+            }
+            if (cls.indexOf('language-') === 0) {
+                return cls.substring('language-'.length);
+            }
+            if (cls.indexOf('lang-') === 0) {
+                return cls.substring('lang-'.length);
+            }
+        }
+        return '';
+    }
 
-	codeElement = null;
-	titleElement = null;
-	copyElement = null;
+    function sanitizeStyleName(name) {
+        if (typeof name !== 'string') {
+            return '';
+        }
+        var normalized = name.trim();
+        return /^[\w-]+$/.test(normalized) ? normalized : '';
+    }
 
-	constructor({ showln = false, cssName, content, language, originalElement }, rootDirname) {
-		this.showln = showln;
-		this.cssName = cssName;
-		this.content = content;
-		this.language = language;
+    function IframeSandbox(config, rootDirname) {
+        this.config = config;
+        this.rootDirname = rootDirname;
+        this.iframe = document.createElement('iframe');
+        this.iframe.src = rootDirname + '/highlight/template.html';
+        this.iframe.title = config.language || 'code block';
+        this.iframe.setAttribute('sandbox', 'allow-scripts allow-clipboard-write');
+        this.iframe.allow = 'clipboard-write';
+        this.iframe.style.width = '100%';
+        this.iframe.style.border = 'none';
+        this.iframe.style.overflow = 'hidden';
+        this.iframe.style.borderRadius = '4px';
+        this.iframe.style.padding = '0';
+        this._handleMessage = this._handleMessage.bind(this);
+        window.addEventListener('message', this._handleMessage, false);
+        config.originalElement.parentNode.replaceChild(this.iframe, config.originalElement);
+        var self = this;
+        this.iframe.addEventListener('load', function () {
+            self._postConfig();
+        });
+    }
 
-		this.iframe = document.createElement("iframe");
-		this.iframe.src = `${rootDirname}/highlight/template.html`;
-		this.iframe.title = language;
-		this.iframe.style = `
-			width: 100%;
-			height: 83.33px;
-			border: none;
-			overflow: hidden;
-			border-radius: 4px;
-			padding: 0 !important;
-		`;
-		originalElement.replaceWith(this.iframe);
+    IframeSandbox.prototype._postConfig = function () {
+        if (!this.iframe.contentWindow) {
+            return;
+        }
+        var cssName = sanitizeStyleName(this.config.cssName) || 'atom-one-light';
+        this.iframe.contentWindow.postMessage({
+            type: 'render',
+            payload: {
+                cssName: cssName,
+                language: this.config.language || '',
+                content: this.config.content || '',
+                showLineNumber: !!this.config.showln,
+            },
+        }, '*');
+    };
 
-		this.window = this.iframe.contentWindow;
+    IframeSandbox.prototype._handleMessage = function (event) {
+        if (event.source !== this.iframe.contentWindow || !event.data) {
+            return;
+        }
+        var data = event.data;
+        if (data.type === 'ready') {
+            this._postConfig();
+            return;
+        }
+        if (data.type === 'resize' && data.payload) {
+            var height = Number(data.payload.height);
+            if (!isNaN(height) && height > 0) {
+                this.iframe.style.height = height + 'px';
+            }
+        }
+    };
 
-		this.iframe.onload = () => {
-			this.loadStatic();
+    IframeSandbox.prototype.destroy = function () {
+        window.removeEventListener('message', this._handleMessage, false);
+    };
 
-			this.codeElement = this.window.document.querySelector("code");
-			this.titleElement = this.window.document.querySelector(".title");
-			this.copyElement = this.window.document.querySelector(".copy");
+    function collectCodeBlocks() {
+        var preList = document.getElementsByTagName('pre');
+        var blocks = [];
+        for (var i = 0; i < preList.length; i += 1) {
+            var pre = preList[i];
+            var code = pre.querySelector('code');
+            if (!code) {
+                continue;
+            }
+            blocks.push({
+                originalElement: pre,
+                codeElement: code,
+            });
+        }
+        return blocks;
+    }
 
-			this.render();
-		};
-	}
+    function render(config) {
+        if (!config || !config.rootDirname) {
+            return;
+        }
+        var styleName = sanitizeStyleName(config.styleName) || 'atom-one-light';
+        var showLineNumber = !!config.showLineNumber;
+        var rootDirname = config.rootDirname.replace(/\/$/, '');
+        var codeBlocks = collectCodeBlocks();
+        for (var i = 0; i < codeBlocks.length; i += 1) {
+            var block = codeBlocks[i];
+            var language = detectLanguage(block.codeElement);
+            var content = block.codeElement.textContent || '';
+            new IframeSandbox({
+                cssName: styleName,
+                language: language,
+                content: content,
+                showln: showLineNumber,
+                originalElement: block.originalElement,
+            }, rootDirname);
+        }
+    }
 
-	loadStatic() {
-		const styleLink = document.createElement("link");
-		styleLink.href = `./styles/${this.cssName}.min.css`;
-		styleLink.rel = "stylesheet";
-		styleLink.type = "text/css";
-		this.window.document.head.appendChild(styleLink);
-	}
-
-	render() {
-		this.window.document.documentElement.setAttribute("theme", this.cssName.includes("dark") ? "dark" : "light");
-		this.codeElement.classList.add(`language-${this.language}`);
-		this.titleElement.innerHTML = this.language;
-		this.codeElement.innerHTML = this.content;
-		this.copyElement.onclick = () => {
-			copy(this.content);
-			this.copyElement.innerHTML = "已复制";
-			this.copyElement.style.color = "#2080f0";
-			setTimeout(() => {
-				this.copyElement.innerHTML = "复制";
-				this.copyElement.style.color = "#666";
-			}, 1000);
-		};
-
-		this.window.hljs.highlightElement(this.codeElement);
-		if (this.showln) {
-			this.window.hljs.initLineNumbersOnLoad();
-		}
-		setTimeout(() => {
-			this.iframe.style.height = `${this.window.document.body.scrollHeight}px`;
-		}, 0);
-	}
-}
-
-function escape2Html(str) {
-	var arrEntities = { lt: "<", gt: ">", nbsp: " ", amp: "&", quot: '"' };
-
-	return str.replace(/&(lt|gt|nbsp|amp|quot);/gi, function (all, t) {
-		return arrEntities[t];
-	});
-}
-
-async function copy(copyTxt) {
-	try {
-		// 对copyTxt进行转义, 防止特殊字符导致复制失败
-		await navigator.clipboard.writeText(escape2Html(copyTxt));
-		// console.log('Page URL copied to clipboard');
-	} catch (err) {
-		console.error("Failed to copy: ", err);
-	}
-}
+    global.TypechoCodeHighlight = {
+        render: render,
+    };
+})(window);


### PR DESCRIPTION
## Summary
- refactor the plugin footer script to call a new TypechoCodeHighlight renderer with sanitized configuration values
- replace the legacy iframe manipulation logic with a sandboxed renderer that uses postMessage, textContent, and validated style names
- move copy, theming, and resize handling into the sandbox template so code highlighting runs in an isolated context

## Testing
- php -l Plugin.php

------
https://chatgpt.com/codex/tasks/task_e_68d452bc99d8832bb2571888dbe42229